### PR TITLE
Location/date/time combo check

### DIFF
--- a/app.R
+++ b/app.R
@@ -381,6 +381,10 @@ server <- function(input, output, session) {
   df.flags  <- reactive({
             unlist(dfs()[[3]])
         })
+  unmatchedtimes  <- reactive({
+                      dfs()[[4]]
+        })
+  
 
 ### Last File to be Processed
   file.processed <- eventReactive(input$process, {

--- a/app.R
+++ b/app.R
@@ -400,16 +400,20 @@ server <- function(input, output, session) {
       geterrmessage()
     }else{
       removeModal()
+      # Create modal dialog box if location and date/time do not match any records in database. Could mean incorrect times on MWRA data.  
+      if (nrow(unmatchedtimes())>0) {
+        displaytable <- reactive({
+          unmatchedtimes()[c("ID","UniqueID")]
+        })
+        showModal(modalDialog(
+          title = "Warning: Sample(s) with unmatched times processed.",
+          HTML("<h4>Data processing was successful.<br/><br/>At least one location had a date and time not present in the database.<br/>Check for incorrect times before importing.<br/>IDs and UniqeIDs for the samples with unmatched times are presented below and have also been printed to the WIT log.</h4><br/>"),
+          renderDataTable(displaytable())
+        ))
+      }      
       paste0('The file "', input$file, '" was successfully processed')
       
-      # Create modal dialog box if location and date/time do not match any records in database. Could mean incorrect times on MWRA data.  
-      if (nrow(unmatchedtimes)>0) {
-        showModal(modalDialog(
-          title = "Sample(s) with unmatched times processed.",
-          HTML("<h4>Data processing was successful.<br/>At least one location had a date and time not present in the database.<br/>Check for incorrect times before importing.<br/>UniqeIDs are presented below and have been printed to the log.</h4><br/>"),
-          print(unmatchedtimes[c("UniqueID")],right=FALSE)
-        ))
-      }
+
     }
   })
 
@@ -500,7 +504,7 @@ server <- function(input, output, session) {
           removeModal()
           if (length(which(df.wq()$Location =="MISC"))>0) {
             showModal(modalDialog(
-              title = "MISC Sample(s) Imported",
+              title = "Warning: MISC Sample(s) Imported",
               HTML("<h4>Data import was successful.<br/>At least one MISC sample was imported.<br/>Add the locations of all MISC samples to tblMiscSample.</h4>")
             ))
           } 

--- a/app.R
+++ b/app.R
@@ -397,14 +397,26 @@ server <- function(input, output, session) {
     }else{
       removeModal()
       paste0('The file "', input$file, '" was successfully processed')
+      
+      # Create modal dialog box if location and date/time do not match any records in database. Could mean incorrect times on MWRA data.  
+      if (nrow(unmatchedtimes)>0) {
+        showModal(modalDialog(
+          title = "Sample(s) with unmatched times processed.",
+          HTML("<h4>Data processing was successful.<br/>At least one location had a date and time not present in the database.<br/>Check for incorrect times before importing.<br/>UniqeIDs are presented below and have been printed to the log.</h4><br/>"),
+          print(unmatchedtimes[c("UniqueID")],right=FALSE)
+        ))
+      }
     }
   })
+
 
   # Text Output
   output$text.process.status <- renderText({
     process.status()
     })
+  
 
+  
   # Show import button and tables when process button is pressed
   # Use of req() later will limit these to only show when process did not create an error)
   observeEvent(input$process, {
@@ -426,7 +438,6 @@ server <- function(input, output, session) {
     )
   }
   
- 
 ### Import UI ####
 
   # Import Action Button - Will only be shown when a file is processed successfully

--- a/src/Wachusett/ImportMWRA.R
+++ b/src/Wachusett/ImportMWRA.R
@@ -11,15 +11,15 @@
 # COMMENT OUT BELOW WHEN RUNNING FUNCTION IN SHINY
 
 # # Load libraries needed
-    # library(tidyverse)
-    # library(stringr)
-    # library(odbc)
-    # library(RODBC)
-    # library(DBI)
-    # library(lubridate)
-    # library(magrittr)
-    # library(readxl)
-#
+# library(tidyverse)
+# library(stringr)
+# library(odbc)
+# library(RODBC)
+# library(DBI)
+# library(lubridate)
+# library(magrittr)
+# library(readxl)
+# 
 # COMMENT OUT ABOVE CODE WHEN RUNNING IN SHINY!
 
 #############################
@@ -196,6 +196,26 @@ Eliminate all duplicates before proceeding.",
              "The duplicate records include:", paste(head(dupes2$UniqueID, 15), collapse = ", ")), call. = FALSE)
 }
 rm(Uniq)
+
+### Check for sample location/time combination already in database. Create dataframe for records with no matches (possible time fix needed)
+
+unmatchedtimes <- df.wq[NULL,names(df.wq)]
+mindatecheck <- min(df.wq$SampleDateTime)
+databasetimes <- dbGetQuery(con, paste0("SELECT SampleDateTime, Location FROM ", ImportTable," WHERE SampleDateTime >= #",mindatecheck,"#"))
+
+for (i in 1:nrow(df.wq)){
+    if ((df.wq$SampleDateTime[i] %in% dplyr::filter(databasetimes,Location==df.wq$Location[i])$SampleDateTime) == FALSE){
+    unmatchedtimes <- bind_rows(unmatchedtimes,df.wq[i,])
+    }}
+
+rm(mindatecheck, databasetimes)
+
+### Print unmatchedtimes to log, if present
+if (nrow(unmatchedtimes)>0){
+  print(paste0(nrow(unmatchedtimes)," unmatched site/date/times in processed data."))
+  print(unmatchedtimes[c("UniqueID","ResultReported")],print.gap=4,right=FALSE)
+}
+
 
 ### DataSource
 df.wq <- df.wq %>% mutate(DataSource = paste0("MWRA_", file))
@@ -388,6 +408,7 @@ dfs <- list()
 dfs[[1]] <- df.wq
 dfs[[2]] <- path
 dfs[[3]] <- df.flags # Removed condition to test for flags and put it in the setFlagIDS() function
+dfs[[4]] <- unmatchedtimes # Samples with site/time combo not matching any record in the database
 
 # Disconnect from db and remove connection obj
 dbDisconnect(con)
@@ -404,6 +425,7 @@ return(dfs)
 # df.wq     <- dfs[[1]]
 # path      <- dfs[[2]]
 # df.flags  <- dfs[[3]]
+# unmatchedtimes <- dfs[[4]]
 
 ########################################################################################################
 ##########################


### PR DESCRIPTION
Created a check in ImportMWRA.R to compare data being imported with locations/date/time combinations in the database. Filters out well locations before check. Saves any unmatched times to the log and adds it to dfs[[4]] for a modal in app.R.

app.R updated to show modal after processing if unmatched times are found and instructs the user to make sure times are correct before importing.