### PR TITLE
Duplicate/Blank evaluation

### DIFF
--- a/src/Functions/WITQCTEST.R
+++ b/src/Functions/WITQCTEST.R
@@ -40,8 +40,8 @@ QCCHECK <- function(df.qccheck, file, ImportTable){
   tz <- 'UTC'
   con <- dbConnect(odbc::odbc(), dsn = dsn, uid = dsn, pwd = config[["DB Connection PW"]], timezone = tz)
   
-  
-dup_df <- dbReadTable(con, Id(schema = schema, table = "tbl_Field_QC"))
+  # Get dataframe for duplicate/blank locations
+  dup_df <- dbReadTable(con, Id(schema = schema, table = "tbl_Field_QC"))
 
   dbDisconnect(con)
   rm(con)
@@ -150,83 +150,100 @@ dups <- df.qccheckNOgauge %>% filter(Location %in% c("WFD1","WFD2","WFD3")) %>%
   rename(Duplicate = Location) %>%
   mutate(Date = as.Date(DateTimeET))
 
+# Only proceed if there are duplicates in the data
 if(nrow(dups)>0){
 
+# Rename column for joining  
 dup_df_rename <- dup_df %>% rename(Duplicate = Dup_Blank_code)
 
+# Join duplicates with locations
 dups <- inner_join(dups, dup_df_rename, by=c("Date","Duplicate")) %>% 
   rename(Location = MWRA_Location) %>%
   select(Date, Duplicate, Location, Parameter, Units, FinalResult)
 
+# Add date to original dataset
 df.qccheckNOgauge.date <- df.qccheckNOgauge %>% mutate(Date = as.Date(DateTimeET))
 
+# Combine duplicate and trib results
 dups_combined <- inner_join(dups, df.qccheckNOgauge.date, by=c("Date","Location","Parameter","Units")) %>%
   rename(TribResult = "FinalResult.y",
-         DupResult = "FinalResult.x") %>%
-  mutate(RPD = round(((abs(TribResult-DupResult)/((TribResult+DupResult)/2))*100),digits=1))
+         DupResult = "FinalResult.x")
 
 ### Calculating RPD for bacteria dups
+
+#Create function for evaluating bacteria RPD
+BACT_DUP_TEST <- function(TribResult, DupResult, RPD){
+  if_else((abs(TribResult - DupResult) <= 50), "PASS",
+          case_when((TribResult > 5000 | DupResult > 5000) & RPD >= 5 ~ "FAIL",
+                    (TribResult > 500 | DupResult > 500) & RPD >= 10 ~ "FAIL",
+                    (TribResult > 50 | DupResult > 50) & RPD >= 20 ~ "FAIL",
+                    RPD >= 30 ~ "FAIL",
+                    TRUE ~ "PASS"))
+}
+
+# Analyze bacteria dups
 bact_dups <- dups_combined %>% 
   filter(Parameter == "E. coli") %>%
   mutate(Log10DupResult = log10(DupResult),
          Log10TribResult = log10(TribResult),
          RPD = round(((abs(Log10TribResult-Log10DupResult)/((Log10TribResult+Log10DupResult)/2))*100),digits=1),
-         Pass = if_else((abs(TribResult - DupResult) <= 50), "PASS",
-                        if_else(TribResult < 5000 & DupResult < 5000,
-                                if_else(TribResult < 500 & DupResult < 500,
-                                        if_else(TribResult < 50 & DupResult < 50,
-                                                if_else(RPD>20, "FAIL","PASS"),
-                                                if_else(RPD>30, "FAIL","PASS")),
-                                        if_else(RPD > 10, "FAIL","PASS")),
-                                if_else(RPD > 5, "FAIL", "PASS"))))
+         Pass = BACT_DUP_TEST(TribResult, DupResult, RPD))
 
-
+# Analyze any DO dups
 DO_temp_dups <- dups_combined %>% 
   filter(Parameter %in% c("Dissolved Oxygen", "Water Temperature")) %>%
   mutate(RPD=abs(TribResult-DupResult),
          Pass = if_else(RPD>0.2, "FAIL","PASS"))
 
+# Analyze all other dups
 dups_other <- dups_combined %>% 
   filter(!Parameter %in% c("E. coli", "Dissolved Oxygen", "Water Temperature","Oxygen Saturation")) %>%
   mutate(RPD = round(((abs(TribResult-DupResult)/((TribResult+DupResult)/2))*100),digits=1),
          Pass = if_else(RPD>30, "FAIL","PASS"))
 
-
+#Combine datasets
 dups_all <- bind_rows(bact_dups, DO_temp_dups, dups_other)
 
+#Get failed dups
 dups_fail <- filter(dups_all, Pass == "FAIL") %>%
                 rename(DupCode = Duplicate,
                        SampleResult = TribResult,
                        DuplicateResult = DupResult)
 }else{
+  #If no duplicates in data, create an empty dataframe for failed duplicates
   dups_fail<-as.data.frame(NULL)
 }
 
 ### Blanks
 
+#Get blanks
 blanks <- df.qccheckNOgauge %>% filter(Location %in% c("WFB1","WFB2")) %>%
   rename(Blank = Location) %>%
   mutate(Date = as.Date(DateTimeET))
 
+#Only proceed if there are blanks in the data
 if(nrow(blanks)>0){
 
+#Rename for joining  
 blank_df_rename <- dup_df %>% rename(Blank = Dup_Blank_code)
 
+#Join blanks with locations
 blanks <- inner_join(blanks, blank_df_rename, by=c("Date","Blank")) %>% 
   rename(Location = MWRA_Location) 
 
+#Calculate whether blanks fail
 blanks <- blanks %>% mutate(
                       Pass = case_when(
-                        str_detect(blanks$Parameter,"Turbidity NTU") ~ if_else(blanks$FinalResult<1, "PASS","FAIL"),
-                        str_detect(blanks$ResultReported,"<") ~ "PASS",
+                        (Parameter=="Turbidity NTU" & FinalResult >=1) ~ "FAIL",
                         (str_detect(blanks$ResultReported,"<")==FALSE) ~ "FAIL",
-                          )
+                          TRUE ~ "PASS")
                             )
-
+# Get only failed blanks
 blanks_fail <- filter(blanks, Pass == "FAIL") %>%
   dplyr::rename(ID = ID.x,
                 BlankCode = Blank)
 }else{
+  #If there are no blanks, make empty dataframe for failed blanks
   blanks_fail <- as.data.frame(NULL)}
 
 
@@ -286,67 +303,6 @@ if ((nrow(rangeoutliers) + nrow(statoutliers) + nrow(dups_fail) + nrow(blanks_fa
 
   qc_message <- paste0("File ",file," processed at ",Sys.time()," with QC warning. See QC Log ",paste0(ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"))
   
-
-
-
-
-
-# 
-# 
-#   # If values exist outside historical range for site/parameter/units, print QC log file, create message for email.
-#   if (nrow(rangeoutliers)>0 & nrow(statoutliers)==0){
-#     options(width=10000)
-#     rangeoutliers <- rangeoutliers %>% arrange(ID)
-#     sink(file = paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
-#     cat("WIT Quality Control Log\n\n")
-#     cat(paste0("Data imported at: ",Sys.time(),"\n"))
-#     cat(paste0("File: ",file,"\n"))
-#     cat(paste0("Database table: ",ImportTable,"\n\n"))
-#     cat(paste0(nrow(rangeoutliers)," record(s) outside historical range.\n\n"),append=T)
-#     capture.output(print(rangeoutliers[c("ID","Location","DateTimeET","Parameter","Units","FinalResult","HistoricalMin","HistoricalMean","HistoricalMax")],print.gap=3,right=F,row.names=F),file=paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
-#     cat("\n\n")
-#     sink()
-#     qc_message <- paste0("File ",file," processed at ",Sys.time(),". ",nrow(rangeoutliers)," record(s) outside historical range. See QC Log ",paste0(ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"))
-#     
-#   } else{
-#     
-#     # If values exist outside statistical range for site/parameter/units, print QC log file
-#     if (nrow(rangeoutliers)==0 & nrow(statoutliers)>0){
-#       options(width=10000)
-#       statoutliers <- statoutliers %>% arrange(ID)
-#       sink(file = paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
-#       cat("WIT Quality Control Log\n\n")
-#       cat(paste0("Data imported at: ",Sys.time(),"\n"))
-#       cat(paste0("File: ",file,"\n"))
-#       cat(paste0("Database table: ",ImportTable,"\n\n"))
-#       cat(paste0(nrow(statoutliers)," potential statistical outlier(s) in imported data.\n\n"),append=T)
-#       capture.output(print(statoutliers[c("ID","Location","DateTimeET","Parameter","Units","FinalResult","HistoricalMin","Percentile25","HistoricalMedian","Percentile75","HistoricalMax")],print.gap=3,right=F,row.names=F),file=paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
-#       cat("\n\n")
-#       sink()
-#       qc_message <- paste0("File ",file," processed at ",Sys.time(),". ",nrow(statoutliers)," potential statistical outlier(s) identified. See QC Log ",paste0(ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"))
-#       
-#     } else{
-#       
-#       # If values exist outside both historical and statistical ranges for site/parameter/units, print QC log file
-#       if (nrow(rangeoutliers)>0 & nrow(statoutliers)>0){
-#         options(width=10000)
-#         rangeoutliers <- rangeoutliers %>% arrange(ID)
-#         statoutliers <- statoutliers %>% arrange(ID)
-#         sink(file = paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
-#         cat("WIT Quality Control Log\n\n")
-#         cat(paste0("Data imported at: ",Sys.time(),"\n"))
-#         cat(paste0("File: ",file,"\n"))
-#         cat(paste0("Database table: ",ImportTable,"\n\n"))
-#         cat(paste0(nrow(rangeoutliers)," record(s) outside historical range.\n\n"),append=T)
-#         capture.output(print(rangeoutliers[c("ID","Location","DateTimeET","Parameter","Units","FinalResult","HistoricalMin","HistoricalMean","HistoricalMax")],print.gap=3,right=F,row.names=F),file=paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
-#         sink()
-#         sink(file = paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append = T)
-#         cat(paste0("\n\n",nrow(statoutliers)," potential statistical outlier(s) in imported data.\n\n"),append=T)
-#         capture.output(print(statoutliers[c("ID","Location","DateTimeET","Parameter","Units","FinalResult","HistoricalMin","Percentile25","HistoricalMedian","Percentile75","HistoricalMax")],print.gap=3,right=F,row.names=F),file=paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
-#         cat("\n\n")
-#         sink()
-#         qc_message <- paste0("File ",file," processed at ",Sys.time(),". ",nrow(rangeoutliers)," record(s) outside historical range and ",nrow(statoutliers)," potential statistical outlier(s) identified. See QC Log ",paste0(ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"))
-        
       } else {
         
       # If no historical or statistical outliers, prints line to WIT log

--- a/src/Functions/WITQCTEST.R
+++ b/src/Functions/WITQCTEST.R
@@ -30,6 +30,22 @@ QCCHECK <- function(df.qccheck, file, ImportTable){
   list2env(data ,.GlobalEnv)
   rm(data)
 
+
+### Get table to match up QC dups/blanks  
+  
+  ### Connect to Database ####  
+  dsn <- "DCR_DWSP_App_R"
+  database <- "DCR_DWSP"
+  schema <- 'Wachusett'
+  tz <- 'UTC'
+  con <- dbConnect(odbc::odbc(), dsn = dsn, uid = dsn, pwd = config[["DB Connection PW"]], timezone = tz)
+  
+  
+dup_df <- dbReadTable(con, Id(schema = schema, table = "tbl_Field_QC"))
+
+  dbDisconnect(con)
+  rm(con)
+  
 ### Create empty dataframes for QC results with output column names
 statoutliers <- df.qccheck[NULL,names(df.qccheck)]
 statoutliers<-dplyr::mutate(statoutliers, HistoricalMin=NA, Percentile25=NA, HistoricalMedian=NA, Percentile75=NA, HistoricalMax=NA, IQR=NA)
@@ -129,6 +145,91 @@ for (i in 1:nrow(df.qccheck)){
       }}}}}}}}
 
 
+### Checking duplicates and blanks
+dups <- df.qccheckNOgauge %>% filter(Location %in% c("WFD1","WFD2","WFD3")) %>%
+  rename(Duplicate = Location) %>%
+  mutate(Date = as.Date(DateTimeET))
+
+if(nrow(dups)>0){
+
+dup_df_rename <- dup_df %>% rename(Duplicate = Dup_Blank_code)
+
+dups <- inner_join(dups, dup_df_rename, by=c("Date","Duplicate")) %>% 
+  rename(Location = MWRA_Location) %>%
+  select(Date, Duplicate, Location, Parameter, Units, FinalResult)
+
+df.qccheckNOgauge.date <- df.qccheckNOgauge %>% mutate(Date = as.Date(DateTimeET))
+
+dups_combined <- inner_join(dups, df.qccheckNOgauge.date, by=c("Date","Location","Parameter","Units")) %>%
+  rename(TribResult = "FinalResult.y",
+         DupResult = "FinalResult.x") %>%
+  mutate(RPD = round(((abs(TribResult-DupResult)/((TribResult+DupResult)/2))*100),digits=1))
+
+### Calculating RPD for bacteria dups
+bact_dups <- dups_combined %>% 
+  filter(Parameter == "E. coli") %>%
+  mutate(Log10DupResult = log10(DupResult),
+         Log10TribResult = log10(TribResult),
+         RPD = round(((abs(Log10TribResult-Log10DupResult)/((Log10TribResult+Log10DupResult)/2))*100),digits=1),
+         Pass = if_else((abs(TribResult - DupResult) <= 50), "PASS",
+                        if_else(TribResult < 5000 & DupResult < 5000,
+                                if_else(TribResult < 500 & DupResult < 500,
+                                        if_else(TribResult < 50 & DupResult < 50,
+                                                if_else(RPD>20, "FAIL","PASS"),
+                                                if_else(RPD>30, "FAIL","PASS")),
+                                        if_else(RPD > 10, "FAIL","PASS")),
+                                if_else(RPD > 5, "FAIL", "PASS"))))
+
+
+DO_temp_dups <- dups_combined %>% 
+  filter(Parameter %in% c("Dissolved Oxygen", "Water Temperature")) %>%
+  mutate(RPD=abs(TribResult-DupResult),
+         Pass = if_else(RPD>0.2, "FAIL","PASS"))
+
+dups_other <- dups_combined %>% 
+  filter(!Parameter %in% c("E. coli", "Dissolved Oxygen", "Water Temperature","Oxygen Saturation")) %>%
+  mutate(RPD = round(((abs(TribResult-DupResult)/((TribResult+DupResult)/2))*100),digits=1),
+         Pass = if_else(RPD>30, "FAIL","PASS"))
+
+
+dups_all <- bind_rows(bact_dups, DO_temp_dups, dups_other)
+
+dups_fail <- filter(dups_all, Pass == "FAIL") %>%
+                rename(DupCode = Duplicate,
+                       SampleResult = TribResult,
+                       DuplicateResult = DupResult)
+}else{
+  dups_fail<-as.data.frame(NULL)
+}
+
+### Blanks
+
+blanks <- df.qccheckNOgauge %>% filter(Location %in% c("WFB1","WFB2")) %>%
+  rename(Blank = Location) %>%
+  mutate(Date = as.Date(DateTimeET))
+
+if(nrow(blanks)>0){
+
+blank_df_rename <- dup_df %>% rename(Blank = Dup_Blank_code)
+
+blanks <- inner_join(blanks, blank_df_rename, by=c("Date","Blank")) %>% 
+  rename(Location = MWRA_Location) 
+
+blanks <- blanks %>% mutate(
+                      Pass = case_when(
+                        str_detect(blanks$Parameter,"Turbidity NTU") ~ if_else(blanks$FinalResult<1, "PASS","FAIL"),
+                        str_detect(blanks$ResultReported,"<") ~ "PASS",
+                        (str_detect(blanks$ResultReported,"<")==FALSE) ~ "FAIL",
+                          )
+                            )
+
+blanks_fail <- filter(blanks, Pass == "FAIL") %>%
+  dplyr::rename(ID = ID.x,
+                BlankCode = Blank)
+}else{
+  blanks_fail <- as.data.frame(NULL)}
+
+
 ### Print results of outlier check to unique WIT log
 QC_log_dir <- paste0(wach_team_root, config[["QC_Logfiles"]])
   # Delete a log of the same name if it exists
@@ -136,59 +237,115 @@ QC_log_dir <- paste0(wach_team_root, config[["QC_Logfiles"]])
     file.remove(paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"))
   }
 
-  # If values exist outside historical range for site/parameter/units, print QC log file, create message for email.
-  if (nrow(rangeoutliers)>0 & nrow(statoutliers)==0){
-    options(width=10000)
+### If any failed duplicates, add note about it.
+
+if ((nrow(rangeoutliers) + nrow(statoutliers) + nrow(dups_fail) + nrow(blanks_fail))>0){
+  
+  options(width=10000)
+  sink(file = paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
+  cat("WIT Quality Control Log\n\n")
+  cat(paste0("Data imported at: ",Sys.time(),"\n"))
+  cat(paste0("File: ",file,"\n"))
+  cat(paste0("Database table: ",ImportTable,"\n\n"))
+  sink()
+  if(nrow(blanks_fail)>0){
+    blanks_fail <- blanks_fail %>% arrange(ID)
+    sink(file = paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append = T)
+    cat(paste0(nrow(blanks_fail)," blanks(s) failed.\n\n"),append=T)
+    capture.output(print(blanks_fail[c("ID","Date","Location","BlankCode","Parameter","Units","FinalResult")],print.gap=3,right=F,row.names=F),file=paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
+    cat("\n\n")
+    sink()
+    
+  }
+  if(nrow(dups_fail)>0){
+    dups_fail <- dups_fail %>% arrange(ID)
+    sink(file = paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append = T)
+    cat(paste0(nrow(dups_fail)," duplicate(s) outside acceptable RPD.\n\n"),append=T)
+    capture.output(print(dups_fail[c("ID","Date","Location","DupCode","Parameter","Units","SampleResult","DuplicateResult")],print.gap=3,right=F,row.names=F),file=paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
+    cat("\n\n")
+    sink()
+
+  }
+  if(nrow(rangeoutliers)>0){
     rangeoutliers <- rangeoutliers %>% arrange(ID)
-    sink(file = paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
-    cat("WIT Quality Control Log\n\n")
-    cat(paste0("Data imported at: ",Sys.time(),"\n"))
-    cat(paste0("File: ",file,"\n"))
-    cat(paste0("Database table: ",ImportTable,"\n\n"))
+    sink(file = paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append = T)
     cat(paste0(nrow(rangeoutliers)," record(s) outside historical range.\n\n"),append=T)
     capture.output(print(rangeoutliers[c("ID","Location","DateTimeET","Parameter","Units","FinalResult","HistoricalMin","HistoricalMean","HistoricalMax")],print.gap=3,right=F,row.names=F),file=paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
     cat("\n\n")
     sink()
-    qc_message <- paste0("File ",file," processed at ",Sys.time(),". ",nrow(rangeoutliers)," record(s) outside historical range. See QC Log ",paste0(ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"))
-    
-  } else{
-    
-    # If values exist outside statistical range for site/parameter/units, print QC log file
-    if (nrow(rangeoutliers)==0 & nrow(statoutliers)>0){
-      options(width=10000)
-      statoutliers <- statoutliers %>% arrange(ID)
-      sink(file = paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
-      cat("WIT Quality Control Log\n\n")
-      cat(paste0("Data imported at: ",Sys.time(),"\n"))
-      cat(paste0("File: ",file,"\n"))
-      cat(paste0("Database table: ",ImportTable,"\n\n"))
-      cat(paste0(nrow(statoutliers)," potential statistical outlier(s) in imported data.\n\n"),append=T)
-      capture.output(print(statoutliers[c("ID","Location","DateTimeET","Parameter","Units","FinalResult","HistoricalMin","Percentile25","HistoricalMedian","Percentile75","HistoricalMax")],print.gap=3,right=F,row.names=F),file=paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
-      cat("\n\n")
-      sink()
-      qc_message <- paste0("File ",file," processed at ",Sys.time(),". ",nrow(statoutliers)," potential statistical outlier(s) identified. See QC Log ",paste0(ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"))
-      
-    } else{
-      
-      # If values exist outside both historical and statistical ranges for site/parameter/units, print QC log file
-      if (nrow(rangeoutliers)>0 & nrow(statoutliers)>0){
-        options(width=10000)
-        rangeoutliers <- rangeoutliers %>% arrange(ID)
-        statoutliers <- statoutliers %>% arrange(ID)
-        sink(file = paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
-        cat("WIT Quality Control Log\n\n")
-        cat(paste0("Data imported at: ",Sys.time(),"\n"))
-        cat(paste0("File: ",file,"\n"))
-        cat(paste0("Database table: ",ImportTable,"\n\n"))
-        cat(paste0(nrow(rangeoutliers)," record(s) outside historical range.\n\n"),append=T)
-        capture.output(print(rangeoutliers[c("ID","Location","DateTimeET","Parameter","Units","FinalResult","HistoricalMin","HistoricalMean","HistoricalMax")],print.gap=3,right=F,row.names=F),file=paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
-        sink()
-        sink(file = paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append = T)
-        cat(paste0("\n\n",nrow(statoutliers)," potential statistical outlier(s) in imported data.\n\n"),append=T)
-        capture.output(print(statoutliers[c("ID","Location","DateTimeET","Parameter","Units","FinalResult","HistoricalMin","Percentile25","HistoricalMedian","Percentile75","HistoricalMax")],print.gap=3,right=F,row.names=F),file=paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
-        cat("\n\n")
-        sink()
-        qc_message <- paste0("File ",file," processed at ",Sys.time(),". ",nrow(rangeoutliers)," record(s) outside historical range and ",nrow(statoutliers)," potential statistical outlier(s) identified. See QC Log ",paste0(ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"))
+
+  }
+  if(nrow(statoutliers)>0){
+    statoutliers <- statoutliers %>% arrange(ID)
+    sink(file = paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append = T)
+    cat(paste0(nrow(statoutliers)," potential statistical outlier(s) in imported data.\n\n"),append=T)
+    capture.output(print(statoutliers[c("ID","Location","DateTimeET","Parameter","Units","FinalResult","HistoricalMin","Percentile25","HistoricalMedian","Percentile75","HistoricalMax")],print.gap=3,right=F,row.names=F),file=paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
+    cat("\n\n")
+    sink()
+    }
+
+  qc_message <- paste0("File ",file," processed at ",Sys.time()," with QC warning. See QC Log ",paste0(ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"))
+  
+
+
+
+
+
+# 
+# 
+#   # If values exist outside historical range for site/parameter/units, print QC log file, create message for email.
+#   if (nrow(rangeoutliers)>0 & nrow(statoutliers)==0){
+#     options(width=10000)
+#     rangeoutliers <- rangeoutliers %>% arrange(ID)
+#     sink(file = paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
+#     cat("WIT Quality Control Log\n\n")
+#     cat(paste0("Data imported at: ",Sys.time(),"\n"))
+#     cat(paste0("File: ",file,"\n"))
+#     cat(paste0("Database table: ",ImportTable,"\n\n"))
+#     cat(paste0(nrow(rangeoutliers)," record(s) outside historical range.\n\n"),append=T)
+#     capture.output(print(rangeoutliers[c("ID","Location","DateTimeET","Parameter","Units","FinalResult","HistoricalMin","HistoricalMean","HistoricalMax")],print.gap=3,right=F,row.names=F),file=paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
+#     cat("\n\n")
+#     sink()
+#     qc_message <- paste0("File ",file," processed at ",Sys.time(),". ",nrow(rangeoutliers)," record(s) outside historical range. See QC Log ",paste0(ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"))
+#     
+#   } else{
+#     
+#     # If values exist outside statistical range for site/parameter/units, print QC log file
+#     if (nrow(rangeoutliers)==0 & nrow(statoutliers)>0){
+#       options(width=10000)
+#       statoutliers <- statoutliers %>% arrange(ID)
+#       sink(file = paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
+#       cat("WIT Quality Control Log\n\n")
+#       cat(paste0("Data imported at: ",Sys.time(),"\n"))
+#       cat(paste0("File: ",file,"\n"))
+#       cat(paste0("Database table: ",ImportTable,"\n\n"))
+#       cat(paste0(nrow(statoutliers)," potential statistical outlier(s) in imported data.\n\n"),append=T)
+#       capture.output(print(statoutliers[c("ID","Location","DateTimeET","Parameter","Units","FinalResult","HistoricalMin","Percentile25","HistoricalMedian","Percentile75","HistoricalMax")],print.gap=3,right=F,row.names=F),file=paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
+#       cat("\n\n")
+#       sink()
+#       qc_message <- paste0("File ",file," processed at ",Sys.time(),". ",nrow(statoutliers)," potential statistical outlier(s) identified. See QC Log ",paste0(ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"))
+#       
+#     } else{
+#       
+#       # If values exist outside both historical and statistical ranges for site/parameter/units, print QC log file
+#       if (nrow(rangeoutliers)>0 & nrow(statoutliers)>0){
+#         options(width=10000)
+#         rangeoutliers <- rangeoutliers %>% arrange(ID)
+#         statoutliers <- statoutliers %>% arrange(ID)
+#         sink(file = paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
+#         cat("WIT Quality Control Log\n\n")
+#         cat(paste0("Data imported at: ",Sys.time(),"\n"))
+#         cat(paste0("File: ",file,"\n"))
+#         cat(paste0("Database table: ",ImportTable,"\n\n"))
+#         cat(paste0(nrow(rangeoutliers)," record(s) outside historical range.\n\n"),append=T)
+#         capture.output(print(rangeoutliers[c("ID","Location","DateTimeET","Parameter","Units","FinalResult","HistoricalMin","HistoricalMean","HistoricalMax")],print.gap=3,right=F,row.names=F),file=paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
+#         sink()
+#         sink(file = paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append = T)
+#         cat(paste0("\n\n",nrow(statoutliers)," potential statistical outlier(s) in imported data.\n\n"),append=T)
+#         capture.output(print(statoutliers[c("ID","Location","DateTimeET","Parameter","Units","FinalResult","HistoricalMin","Percentile25","HistoricalMedian","Percentile75","HistoricalMax")],print.gap=3,right=F,row.names=F),file=paste0(QC_log_dir,"/",ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"),append=T)
+#         cat("\n\n")
+#         sink()
+#         qc_message <- paste0("File ",file," processed at ",Sys.time(),". ",nrow(rangeoutliers)," record(s) outside historical range and ",nrow(statoutliers)," potential statistical outlier(s) identified. See QC Log ",paste0(ImportTable,"_",file,"_",format(Sys.Date(),"%Y-%m-%d"),".txt"))
         
       } else {
         
@@ -196,7 +353,6 @@ QC_log_dir <- paste0(wach_team_root, config[["QC_Logfiles"]])
           qc_message <- NA
         
       }
-    }}
 
 ### Returns output message from function for email.
 return(qc_message)


### PR DESCRIPTION
Added an evaluation of duplicates and blanks. 
- Automatically flags any failed duplicates and blanks. 
- Automatically flags any samples of the same parameter sampled on the same date as a failed duplicate or blank. 
- Adds failed duplicates and blanks to QC log file. 
- Streamlines creation of text/tables for QC log file.