### PR TITLE
Staff Gauge Height or Turbidity Time Check

### DIFF
--- a/src/Wachusett/ImportFieldParameters.R
+++ b/src/Wachusett/ImportFieldParameters.R
@@ -220,6 +220,29 @@ if (length(dupes2) > 0){
 }
 rm(Uniq)
 
+### Make sure records have matching stage or turbidity times in database
+DateTimesMatch <- dbGetQuery(con, glue("SELECT DateTimeET, Location FROM {database}.{schema}.{ImportTable} WHERE Parameter IN ('Turbidity NTU','Staff Gauge Height')"))
+DateTimesMatch$DateTimeET <- DateTimesMatch$DateTimeET  %>% force_tz("America/New_York")
+
+### Keep only locations that always have matching stage or turbidity times
+locations_timecheck <- locations %>% filter(LocationType == "Tributary",
+                                            LocationCategory %in% c("Primary","Secondary","Long-term Forestry")) %>%
+  select(LocationMWRA)
+
+### Filter imported data to only the locations above
+df_no_MISC <- df %>% filter(Location %in% locations_timecheck$LocationMWRA)
+
+### Anti-join to only keep records without location/datetime matches in the database
+UnmatchedDateTimes <- anti_join(df_no_MISC, DateTimesMatch, by=c("DateTimeET"))
+
+### If any unmatched times exist, stop processing and show error to user
+if (nrow(UnmatchedDateTimes) > 0){
+  # Exit function and send a warning to user
+  stop(paste0("This data file contains ", nrow(UnmatchedDateTimes),
+              " records with Date/Times not present in Survey123 data for site(s): ", paste(unique(sort(UnmatchedDateTimes$Location)), collapse=", ")))
+  print(UnmatchedDateTimes) # Show the duplicate Unique IDs to user in Shiny
+}
+
 ### DataSource ####
 df$DataSource <- file
 


### PR DESCRIPTION
Adds check for staff gauge height or turbidity time in the database to match with field parameter times. If not found, stops and gives an error which lists how many records and which sites have times not found in staff gauge height or turbidity in database.